### PR TITLE
Added support for Python 2.5. Fixed a timeout error with read.

### DIFF
--- a/ipgetter.py
+++ b/ipgetter.py
@@ -126,7 +126,6 @@ class IPgetter(object):
     def handle_timeout(self, url):
         if url:
             url.close()
-        raise socket.timeout("Timed out.")
 
     def fetch(self, server):
         '''


### PR DESCRIPTION
I noticed another timeout problem: if the connection is interrupted during read() then the thread hangs forever. This was actually the original problem I had with ipgetter as I have extremely flaky Internet (causing my program to randomly stop working when the Internet died during a read), but this patch should fix that. Basically, I've added a thread that automatically closes url after a timeout which will raise an exception in your existing try statement (and since it's a thread - most importantly, it will work during interrupted reads.)

Your code seems to work for all Python versions from latest - 2.6 but I made minor changes to support 2.5. Not sure if you want to merge this but it seems to work perfectly.