### PR TITLE
Remove ip.my-proxy.com

### DIFF
--- a/ipgetter.py
+++ b/ipgetter.py
@@ -64,7 +64,6 @@ class IPgetter(object):
                             'http://checkip.dyndns.org/plain',
                             'http://ipogre.com/linux.php',
                             'http://whatismyipaddress.com/',
-                            'http://ip.my-proxy.com/',
                             'http://websiteipaddress.com/WhatIsMyIp',
                             'http://getmyipaddress.org/',
                             'http://www.my-ip-address.net/',


### PR DESCRIPTION
This site is apparently behind CloudFlare, causing it to print a message that the client is using a transparent proxy. Unfortunately, the regex matches REMOTE_ADDR before the HTTP_X_FORWARDED_FOR - causing it to always believe the client is from this service's own proxy.