### PR TITLE
Remove checkmyip.net

### DIFF
--- a/ipgetter.py
+++ b/ipgetter.py
@@ -79,7 +79,6 @@ class IPgetter(object):
                             'http://www.ip-adress.com/',
                             'http://checkmyip.com/',
                             'http://www.tracemyip.org/',
-                            'http://checkmyip.net/',
                             'http://www.lawrencegoetz.com/programs/ipinfo/',
                             'http://www.findmyip.co/',
                             'http://ip-lookup.net/',


### PR DESCRIPTION
Hostname cannot be resolved

```
checkmyip.net.		172800	IN	NS	ns1.gazduireweb.hosting.
checkmyip.net.		172800	IN	NS	ns2.gazduireweb.hosting.
dig: couldn't get address for 'ns1.gazduireweb.hosting': no more
```