### PR TITLE
console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from distutils.core import setup
-            
+
 setup(
     name='ipgetter',
     version='0.6',
@@ -21,8 +21,11 @@ setup(
     ],
 
     py_modules=['ipgetter'],
+    entry_points={
+        'console_scripts': ['ipgetter=ipgetter:myip']
+    },
 
-    long_description='''This module is designed to fetch your external IP address from the internet. It is used mostly when behind a NAT. It picks your IP 
+    long_description='''This module is designed to fetch your external IP address from the internet. It is used mostly when behind a NAT. It picks your IP
 randomly from a serverlist to minimize request overhead on a single server
 
 If you want to add or remove your server from the list contact me on github''',


### PR DESCRIPTION
setup.py entry to create console script on installation.
I find ipgetter useful even by itself, as a command line utility, I guess more people do as well.

Having it as a console script is nice:

```
(env) fopina@IZDEV01:~$ pip install ..path/to/ipgetter/
Processing ../ipgetter
Installing collected packages: ipgetter
  Running setup.py install for ipgetter ... done
Successfully installed ipgetter-0.6
(env) fopina@IZDEV01:~$ ipgetter 
14.66.250.14
```
